### PR TITLE
Expose fold of parsing structure and add map

### DIFF
--- a/src/lib/ParsingStructureUtilities.ml
+++ b/src/lib/ParsingStructureUtilities.ml
@@ -68,22 +68,22 @@ let rec map_parsed_boolean_expression leaf_mod = function
       let e1' = map_parsed_boolean_expression leaf_mod e1 in
       let e2' = map_parsed_boolean_expression leaf_mod e2 in
       Parsed_conj_dis (e1', e2', c)
-	| Parsed_discrete_bool_expr e ->
+  | Parsed_discrete_bool_expr e ->
     Parsed_discrete_bool_expr (map_parsed_discrete_boolean_expression leaf_mod e)
 
 and map_parsed_discrete_boolean_expression leaf_mod = function
   | Parsed_arithmetic_expr e -> Parsed_arithmetic_expr (map_parsed_discrete_arithmetic_expression leaf_mod e)
-	| Parsed_comparison (e1, op, e2) ->
+  | Parsed_comparison (e1, op, e2) ->
       let e1' = map_parsed_discrete_boolean_expression leaf_mod e1 in
       let e2' = map_parsed_discrete_boolean_expression leaf_mod e2 in
       Parsed_comparison (e1', op, e2')
-	| Parsed_comparison_in (e1, e2, e3) ->
+  | Parsed_comparison_in (e1, e2, e3) ->
       let e1' = map_parsed_discrete_arithmetic_expression leaf_mod e1 in
       let e2' = map_parsed_discrete_arithmetic_expression leaf_mod e2 in
       let e3' = map_parsed_discrete_arithmetic_expression leaf_mod e3 in
       Parsed_comparison_in (e1', e2', e3')
-	| Parsed_nested_bool_expr e -> Parsed_nested_bool_expr (map_parsed_boolean_expression leaf_mod e)
-	| Parsed_not e -> Parsed_not (map_parsed_boolean_expression leaf_mod e)
+  | Parsed_nested_bool_expr e -> Parsed_nested_bool_expr (map_parsed_boolean_expression leaf_mod e)
+  | Parsed_not e -> Parsed_not (map_parsed_boolean_expression leaf_mod e)
 
 and map_parsed_discrete_arithmetic_expression leaf_mod = function
   | Parsed_sum_diff (e, t, sum_diff) ->

--- a/src/lib/ParsingStructureUtilities.ml
+++ b/src/lib/ParsingStructureUtilities.ml
@@ -59,7 +59,7 @@ type 'a linear_expression_leaf_callback = linear_expression_leaf -> 'a
 
 type 'a variable_declaration_callback = (variable_name * var_type_discrete * int -> 'a) option
 
-(* Apply a function inside a parsing structure, modifying its leafs *)
+(** Apply a function inside a parsing structure, modifying its leafs *)
 
 type parsing_structure_leaf_modifier = parsing_structure_leaf -> parsing_structure_leaf
 
@@ -105,13 +105,13 @@ and map_parsed_discrete_factor leaf_mod =
         match leaf_mod (Leaf_variable variable_ref) with
           | Leaf_variable variable_ref' -> Parsed_variable variable_ref'
           | Leaf_constant value -> Parsed_constant value
-          | Leaf_fun name -> Parsed_function_call (name, []) (* ? what do we do here *)
+          | Leaf_fun name -> Parsed_function_call (name, [])
         end
     | Parsed_constant value -> begin
       match leaf_mod (Leaf_constant value) with
         | Leaf_variable variable_ref -> Parsed_variable variable_ref
         | Leaf_constant value' -> Parsed_constant value'
-        | Leaf_fun name -> Parsed_function_call (name, [])  (* ... *)
+        | Leaf_fun name -> Parsed_function_call (name, [])
       end
     | Parsed_sequence (expr_list, tp) ->
         let expr_list' = List.map (map_parsed_boolean_expression leaf_mod) expr_list in

--- a/src/lib/ParsingStructureUtilities.ml
+++ b/src/lib/ParsingStructureUtilities.ml
@@ -105,13 +105,15 @@ and map_parsed_discrete_factor leaf_mod =
         match leaf_mod (Leaf_variable variable_ref) with
           | Leaf_variable variable_ref' -> Parsed_variable variable_ref'
           | Leaf_constant value -> Parsed_constant value
-          | Leaf_fun name -> Parsed_function_call (name, [])
+          | Leaf_fun _ -> failwith
+              "[map_parsed_discrete_factor]: the leaf modifier is not supposed to map variables to functions."
         end
     | Parsed_constant value -> begin
       match leaf_mod (Leaf_constant value) with
         | Leaf_variable variable_ref -> Parsed_variable variable_ref
         | Leaf_constant value' -> Parsed_constant value'
-        | Leaf_fun name -> Parsed_function_call (name, [])
+        | Leaf_fun _ -> failwith
+            "[map_parsed_discrete_factor]: the leaf modifier is not supposed to map constants to functions."
       end
     | Parsed_sequence (expr_list, tp) ->
         let expr_list' = List.map (map_parsed_boolean_expression leaf_mod) expr_list in

--- a/src/lib/ParsingStructureUtilities.mli
+++ b/src/lib/ParsingStructureUtilities.mli
@@ -57,6 +57,24 @@ type 'a linear_expression_leaf_callback = linear_expression_leaf -> 'a
 
 type 'a variable_declaration_callback = (variable_name * var_type_discrete * int -> 'a) option
 
+type parsing_structure_leaf_modifier =
+  { variable_modifier : variable_ref -> variable_ref
+  ; constant_modifier : ParsedValue.parsed_value -> ParsedValue.parsed_value
+  ; fun_modifier      : variable_name -> variable_name
+  }
+
+val map_parsed_boolean_expression : parsing_structure_leaf_modifier -> parsed_boolean_expression -> parsed_boolean_expression
+val map_parsed_discrete_boolean_expression : parsing_structure_leaf_modifier -> parsed_discrete_boolean_expression -> parsed_discrete_boolean_expression
+val map_parsed_discrete_arithmetic_expression : parsing_structure_leaf_modifier -> parsed_discrete_arithmetic_expression -> parsed_discrete_arithmetic_expression
+val map_parsed_discrete_term : parsing_structure_leaf_modifier -> parsed_discrete_term -> parsed_discrete_term
+val map_parsed_discrete_factor : parsing_structure_leaf_modifier -> parsed_discrete_factor -> parsed_discrete_factor
+
+val fold_parsed_boolean_expression : ('a -> 'a -> 'a) -> 'a -> 'a parsing_structure_leaf_callback -> parsed_boolean_expression -> 'a
+val fold_parsed_discrete_boolean_expression : ('a -> 'a -> 'a) -> 'a -> 'a parsing_structure_leaf_callback -> parsed_discrete_boolean_expression -> 'a
+val fold_parsed_discrete_arithmetic_expression : ('a -> 'a -> 'a) -> 'a -> 'a parsing_structure_leaf_callback -> parsed_discrete_arithmetic_expression -> 'a
+val fold_parsed_discrete_term : ('a -> 'a -> 'a) -> 'a -> 'a parsing_structure_leaf_callback -> parsed_discrete_term -> 'a
+val fold_parsed_discrete_factor : ('a -> 'a -> 'a) -> 'a -> 'a parsing_structure_leaf_callback -> parsed_discrete_factor -> 'a
+
 val fold_parsed_seq_code_bloc : ('a -> 'a -> 'a) -> 'a -> ?decl_callback:'a variable_declaration_callback -> 'a seq_code_bloc_leaf_callback -> 'a parsing_structure_leaf_callback -> parsed_seq_code_bloc -> 'a
 val fold_parsed_fun_def : ('a -> 'a -> 'a) -> 'a -> ?decl_callback:'a variable_declaration_callback -> 'a seq_code_bloc_leaf_callback -> 'a parsing_structure_leaf_callback -> parsed_fun_definition -> 'a
 val fold_parsed_normal_update : ('a -> 'a -> 'a) -> 'a -> ?decl_callback:'a variable_declaration_callback -> 'a seq_code_bloc_leaf_callback -> 'a parsing_structure_leaf_callback -> normal_update -> 'a

--- a/src/lib/ParsingStructureUtilities.mli
+++ b/src/lib/ParsingStructureUtilities.mli
@@ -57,11 +57,7 @@ type 'a linear_expression_leaf_callback = linear_expression_leaf -> 'a
 
 type 'a variable_declaration_callback = (variable_name * var_type_discrete * int -> 'a) option
 
-type parsing_structure_leaf_modifier =
-  { variable_modifier : variable_ref -> variable_ref
-  ; constant_modifier : ParsedValue.parsed_value -> ParsedValue.parsed_value
-  ; fun_modifier      : variable_name -> variable_name
-  }
+type parsing_structure_leaf_modifier = parsing_structure_leaf -> parsing_structure_leaf
 
 val map_parsed_boolean_expression : parsing_structure_leaf_modifier -> parsed_boolean_expression -> parsed_boolean_expression
 val map_parsed_discrete_boolean_expression : parsing_structure_leaf_modifier -> parsed_discrete_boolean_expression -> parsed_discrete_boolean_expression


### PR DESCRIPTION
This PR does two things:
  - Exposes `fold_parsed_boolean_expression`, `fold_parsed_discrete_boolean_expression`, `fold_parsed_discrete_arithmetic_expression`, `fold_parsed_discrete_term`, `fold_parsed_discrete_map`, used to fold parsed structures.
  - Implements the corresponding `map` functions. These maps receive a function mapping `parsing_structure_leaf` to `parsing_structure_leaf` and apply it to each leaf in the structure. Notice that, if the function maps a `Leaf_constant` to a `Leaf_fun`, the function is applied without any arguments.