### PR TITLE
Adds include directory for gmp to ocamlc

### DIFF
--- a/.github/patches/gmp.patch
+++ b/.github/patches/gmp.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 2e54a3c..dbc1bf5 100644
+index 2e54a3c..6cee915 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,10 +2,10 @@
@@ -29,3 +29,16 @@ index 2e54a3c..dbc1bf5 100644
  #CFLAGS_MISC=
  CFLAGS_INCLUDE= -I $(OCAML_LIBDIR) $(GMP_INCLUDES)
  CFLAGS= $(CFLAGS_MISC) $(CFLAGS_INCLUDE)
+@@ -86,10 +86,10 @@
+ 	$(OCAMLOPT) $+ -o $@
+
+ test_suite:	gmp.cma test_suite.cmo
+-	$(OCAMLC) -custom $+ -o $@
++	$(OCAMLC) -custom -I $(GMP_LIBDIR) $+ -o $@
+
+ test_suite.opt:	gmp.cmxa test_suite.cmx
+-	$(OCAMLOPT) $+ -o $@
++	$(OCAMLOPT) -I $(GMP_LIBDIR) $+ -o $@
+
+ clean:
+ 	rm -f *.o *.cm* $(PROGRAMS) *.a


### PR DESCRIPTION
This PR adds the include directory for GMP in some commands of the Makefile for MLGMP.

It seems that this is necessary in some Mac machines. I could only compile IMITATOR on mine after this patch.