### PR TITLE
New type: `parsed_model_with_templates`

### DIFF
--- a/src/lib/ModelConverter.ml
+++ b/src/lib/ModelConverter.ml
@@ -2658,11 +2658,10 @@ let convert_property_option (useful_parsing_model_information : useful_parsing_m
 (*------------------------------------------------------------*)
 (** Convert the parsed model and the parsed property into an abstract model and an abstract property *)
 (*------------------------------------------------------------*)
-let abstract_structures_of_parsing_structures options (parsed_model : ParsingStructure.parsed_model) (parsed_property_option : ParsingStructure.parsed_property option) : AbstractModel.abstract_model * (AbstractProperty.abstract_property option) =
+let abstract_structures_of_parsing_structures options (parsed_model : ParsingStructure.parsed_model_with_templates) (parsed_property_option : ParsingStructure.parsed_property option) : AbstractModel.abstract_model * (AbstractProperty.abstract_property option) =
 
   (* Instantiate the template calls *)
-  let instantiated_automata = instantiate_automata parsed_model.template_definitions parsed_model.template_calls in
-  let parsed_model = { parsed_model with automata = (parsed_model.automata @ instantiated_automata) } in
+  let parsed_model = instantiate_model parsed_model in
 
   print_message Verbose_high ("\n*** Link variables to declarations.");
   (* Recompute model to link variables to their declarations, and return all variables declarations *)

--- a/src/lib/ModelConverter.mli
+++ b/src/lib/ModelConverter.mli
@@ -34,4 +34,4 @@ exception InvalidProperty
 (* Conversion functions *)
 (****************************************************************)
 (** Convert the parsed model and the parsed property into an abstract model and an abstract property *)
-val abstract_structures_of_parsing_structures : Options.imitator_options -> ParsingStructure.parsed_model -> (ParsingStructure.parsed_property option) -> AbstractModel.abstract_model * (AbstractProperty.abstract_property option)
+val abstract_structures_of_parsing_structures : Options.imitator_options -> ParsingStructure.parsed_model_with_templates -> (ParsingStructure.parsed_property option) -> AbstractModel.abstract_model * (AbstractProperty.abstract_property option)

--- a/src/lib/ModelLexer.mll
+++ b/src/lib/ModelLexer.mll
@@ -46,7 +46,7 @@ rule token = parse
 			let lb = Lexing.from_channel c in
 			lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with Lexing.pos_fname = absolute_filename };
 
-			let p : ParsingStructure.parsed_model = ModelParser.main token lb in
+			let p : ParsingStructure.parsed_model_with_templates = ModelParser.main token lb in
 			INCLUDE p
     }
 

--- a/src/lib/ModelParser.mly
+++ b/src/lib/ModelParser.mly
@@ -32,7 +32,7 @@ let parse_error _ =
 let include_list = ref [];;
 
 let add_parsed_model_to_parsed_model_list parsed_model_list parsed_model =
-	let merged_controllable_actions : ParsingStructure.parsed_controllable_actions = match parsed_model.controllable_actions, parsed_model_list.controllable_actions with
+	let merged_controllable_actions : ParsingStructure.parsed_controllable_actions = match parsed_model.model.controllable_actions, parsed_model_list.model.controllable_actions with
 			| Parsed_no_controllable_actions, Parsed_no_controllable_actions
 				-> Parsed_no_controllable_actions
 
@@ -59,26 +59,32 @@ let add_parsed_model_to_parsed_model_list parsed_model_list parsed_model =
 		in
 
 	{
-		controllable_actions  = merged_controllable_actions;
-		variable_declarations = List.append parsed_model.variable_declarations parsed_model_list.variable_declarations;
-		fun_definitions       = List.append parsed_model.fun_definitions parsed_model_list.fun_definitions;
-		template_definitions  = List.append parsed_model.template_definitions parsed_model_list.template_definitions;
-		automata              = List.append parsed_model.automata parsed_model_list.automata;
-		template_calls        = List.append parsed_model.template_calls parsed_model_list.template_calls;
-		init_definition       = List.append parsed_model.init_definition parsed_model_list.init_definition;
+                model =
+                {
+                        controllable_actions  = merged_controllable_actions;
+                        variable_declarations = List.append parsed_model.model.variable_declarations parsed_model_list.model.variable_declarations;
+                        fun_definitions       = List.append parsed_model.model.fun_definitions parsed_model_list.model.fun_definitions;
+                        automata              = List.append parsed_model.model.automata parsed_model_list.model.automata;
+                        init_definition       = List.append parsed_model.model.init_definition parsed_model_list.model.init_definition;
+                };
+                template_definitions  = List.append parsed_model.template_definitions parsed_model_list.template_definitions;
+                template_calls        = List.append parsed_model.template_calls parsed_model_list.template_calls;
 	}
 ;;
 
 let unzip l = List.fold_left
 	add_parsed_model_to_parsed_model_list
 	{
-		controllable_actions  = Parsed_no_controllable_actions;
-		variable_declarations = [];
-    fun_definitions       = [];
-    template_definitions  = [];
-		automata              = [];
-		template_calls        = [];
-		init_definition       = [];
+                model =
+                {
+                        controllable_actions  = Parsed_no_controllable_actions;
+                        variable_declarations = [];
+                        fun_definitions       = [];
+                        automata              = [];
+                        init_definition       = [];
+                };
+                template_definitions  = [];
+                template_calls        = [];
 	}
 	(List.rev l)
 ;;
@@ -90,7 +96,7 @@ let unzip l = List.fold_left
 %token <string> BINARYWORD
 %token <string> NAME
 /* %token <string> STRING */
-%token <ParsingStructure.parsed_model> INCLUDE
+%token <ParsingStructure.parsed_model_with_templates> INCLUDE
 
 %token OP_PLUS OP_MINUS OP_MUL OP_DIV
 %token OP_L OP_LEQ OP_EQ OP_NEQ OP_GEQ OP_G OP_ASSIGN
@@ -138,7 +144,7 @@ let unzip l = List.fold_left
 
 
 %start main             /* the entry point */
-%type <ParsingStructure.parsed_model> main
+%type <ParsingStructure.parsed_model_with_templates> main
 %%
 
 /************************************************************/
@@ -156,13 +162,16 @@ main:
 
 		let main_model =
 		{
-			controllable_actions  = controllable_actions;
-			variable_declarations = declarations;
-			fun_definitions       = fun_definitions;
-			template_definitions  = template_definitions;
-			automata              = automata;
-			template_calls        = template_calls;
-			init_definition       = init_definition;
+                        model =
+                        {
+                                controllable_actions  = controllable_actions;
+                                variable_declarations = declarations;
+                                fun_definitions       = fun_definitions;
+                                automata              = automata;
+                                init_definition       = init_definition;
+                        };
+                        template_definitions  = template_definitions;
+                        template_calls        = template_calls;
 		}
 		in
 		let included_model = unzip !include_list in

--- a/src/lib/ParsingStructure.mli
+++ b/src/lib/ParsingStructure.mli
@@ -296,13 +296,15 @@ type parsed_model = {
 	controllable_actions  : parsed_controllable_actions;
 	variable_declarations : variable_declarations;
 	fun_definitions       : parsed_fun_definition_list;
-       template_definitions  : parsed_template_definition list;
 	automata              : parsed_automaton list;
-       template_calls        : parsed_template_call list;
 	init_definition       : init_definition;
 }
 
-
+type parsed_model_with_templates = {
+        model                : parsed_model;
+        template_definitions : parsed_template_definition list;
+        template_calls       : parsed_template_call list;
+}
 
 (****************************************************************)
 (* Parsed valuation and valuation domains *)

--- a/src/lib/ParsingUtility.ml
+++ b/src/lib/ParsingUtility.ml
@@ -209,7 +209,7 @@ let compile_model_and_property (options : Options.imitator_options) =
 
 	(* Parsing the main model *)
 	print_message Verbose_low ("Parsing model file " ^ options#model_file_name ^ "…");
-	let parsed_model : ParsingStructure.parsed_model = parser_lexer_from_file Model options ModelParser.main ModelLexer.token options#model_file_name in
+	let parsed_model : ParsingStructure.parsed_model_with_templates = parser_lexer_from_file Model options ModelParser.main ModelLexer.token options#model_file_name in
 
 	(* Statistics *)
 	parsing_counter#stop;

--- a/src/lib/Templates.ml
+++ b/src/lib/Templates.ml
@@ -187,4 +187,7 @@ let instantiate_automaton (templates : parsed_template_definition list) (parsed_
 let instantiate_automata (templates : parsed_template_definition list) (insts : parsed_template_call list) : parsed_automaton list =
     List.map (instantiate_automaton templates) insts
 
+let instantiate_model parsed_model_with_templates =
+    let instantiated_automata = instantiate_automata parsed_model_with_templates.template_definitions parsed_model_with_templates.template_calls in
+    { parsed_model_with_templates.model with automata = (parsed_model_with_templates.model.automata @ instantiated_automata) }
 

--- a/src/lib/Templates.mli
+++ b/src/lib/Templates.mli
@@ -1,3 +1,3 @@
 open ParsingStructure
 
-val instantiate_automata : parsed_template_definition list -> parsed_template_call list -> parsed_automaton list
+val instantiate_model : parsed_model_with_templates -> parsed_model


### PR DESCRIPTION
This type is used to differentiate between the model before the instantiation and after. The parser now returns a value of this type instead of parsed_model, and the API for templates exposes a single function, which has type `parsed_model_with_templates -> parsed_model`.