### PR TITLE
New feature: forall keyword

### DIFF
--- a/src/lib/ModelLexer.mll
+++ b/src/lib/ModelLexer.mll
@@ -85,6 +85,7 @@ rule token = parse
 	| "flow"           { CT_FLOW }
 	| "fn"             { CT_FUN   }
 	| "for"            { CT_FOR }
+  | "forall"         { CT_FORALL }
 	| "from"           { CT_FROM }
 	| "function"       { CT_FUN   }
 	| "goto"           { CT_GOTO }

--- a/src/lib/ModelParser.mly
+++ b/src/lib/ModelParser.mly
@@ -512,7 +512,7 @@ forall_template_call:
       forall_index    = $2;
       forall_lb       = $5;
       forall_ub       = $7;
-      forall_aut_name = $14;
+      forall_aut_name = $11;
       forall_template = $16;
       forall_args     = $18;
     }

--- a/src/lib/ParsingStructure.mli
+++ b/src/lib/ParsingStructure.mli
@@ -131,17 +131,29 @@ type linear_term =
 	| Constant of  NumConst.t
 	| Variable of  NumConst.t * variable_name
 
-
 type linear_expression =
 	| Linear_term of linear_term
 	| Linear_plus_expression of linear_expression * linear_term
 	| Linear_minus_expression of linear_expression * linear_term
 
-
 type linear_constraint =
 	| Parsed_true_constraint (** True *)
 	| Parsed_false_constraint (** False *)
 	| Parsed_linear_constraint of linear_expression * parsed_relop * linear_expression
+
+type unexpanded_linear_term =
+	| Unexpanded_constant of  NumConst.t
+	| Unexpanded_variable of  NumConst.t * name_or_access
+
+type unexpanded_linear_expression =
+	| Unexpanded_linear_term of unexpanded_linear_term
+	| Unexpanded_linear_plus_expression of unexpanded_linear_expression * unexpanded_linear_term
+	| Unexpanded_linear_minus_expression of unexpanded_linear_expression * unexpanded_linear_term
+
+type unexpanded_linear_constraint =
+	| Unexpanded_parsed_true_constraint
+	| Unexpanded_parsed_false_constraint
+	| Unexpanded_parsed_linear_constraint of unexpanded_linear_expression * parsed_relop * unexpanded_linear_expression
 
 (** Non-linear expressions *)
 type nonlinear_constraint = parsed_discrete_boolean_expression
@@ -260,7 +272,7 @@ type unexpanded_parsed_location = {
 	unexpanded_name        : location_name;
 	unexpanded_urgency     : parsed_urgency;
 	unexpanded_acceptance  : parsed_acceptance;
-	unexpanded_cost        : linear_expression option;
+	unexpanded_cost        : unexpanded_linear_expression option;
 	unexpanded_invariant   : invariant;
 	unexpanded_stopped     : name_or_access list;
 	unexpanded_flow        : unexpanded_parsed_flow;
@@ -311,7 +323,9 @@ type unexpanded_parsed_init_state_predicate =
   | Unexpanded_parsed_forall_loc_assignment of
   (*  index info          array name      array index                             location *)
       forall_index_data * variable_name * parsed_discrete_arithmetic_expression * location_name
-	| Unexpanded_parsed_linear_predicate of linear_constraint
+	| Unexpanded_parsed_linear_predicate of unexpanded_linear_constraint
+	| Unexpanded_parsed_forall_linear_predicate of
+		forall_index_data * unexpanded_linear_constraint
 	| Unexpanded_parsed_discrete_predicate of variable_name * parsed_boolean_expression
 
 type unexpanded_init_definition = unexpanded_parsed_init_state_predicate list

--- a/src/lib/ParsingStructure.mli
+++ b/src/lib/ParsingStructure.mli
@@ -368,7 +368,7 @@ type unexpanded_parsed_model = {
     unexpanded_variable_declarations : variable_declarations;
     unexpanded_fun_definitions : parsed_fun_definition_list;
     unexpanded_automata : unexpanded_parsed_automaton list;
-    unexpanded_init_definition : init_definition;
+    unexpanded_init_definition : unexpanded_init_definition;
     template_definitions : parsed_template_definition list;
     template_calls : parsed_template_call list;
     forall_template_calls : parsed_forall_template_call list;

--- a/src/lib/ParsingStructure.mli
+++ b/src/lib/ParsingStructure.mli
@@ -287,6 +287,15 @@ type parsed_template_call =
  (* name             template used   parameters passed to template *)
     automaton_name * template_name * (parsed_template_arg list)
 
+type parsed_forall_template_call = {
+  forall_index    : variable_name;
+  forall_lb       : parsed_discrete_arithmetic_expression;
+  forall_ub       : parsed_discrete_arithmetic_expression;
+  forall_aut_name : automaton_name;
+  forall_template : template_name;
+  forall_args     : parsed_template_arg list; (* Noticed that these are shared between the calls *)
+}
+
 (****************************************************************)
 (* Init definition *)
 (****************************************************************)
@@ -348,6 +357,7 @@ type unexpanded_parsed_model = {
     unexpanded_init_definition : init_definition;
     template_definitions : parsed_template_definition list;
     template_calls : parsed_template_call list;
+    forall_template_calls : parsed_forall_template_call list;
     synt_declarations : parsed_synt_var_decl list;
 }
 

--- a/src/lib/ParsingStructure.mli
+++ b/src/lib/ParsingStructure.mli
@@ -287,13 +287,17 @@ type parsed_template_call =
  (* name             template used   parameters passed to template *)
     automaton_name * template_name * (parsed_template_arg list)
 
+type forall_index_data = {
+  forall_index_name : variable_name;
+  forall_lb         : parsed_discrete_arithmetic_expression;
+  forall_ub         : parsed_discrete_arithmetic_expression;
+}
+
 type parsed_forall_template_call = {
-  forall_index    : variable_name;
-  forall_lb       : parsed_discrete_arithmetic_expression;
-  forall_ub       : parsed_discrete_arithmetic_expression;
-  forall_aut_name : automaton_name;
-  forall_template : template_name;
-  forall_args     : parsed_template_arg list; (* Noticed that these are shared between the calls *)
+  forall_index_data : forall_index_data;
+  forall_aut_name   : automaton_name;
+  forall_template   : template_name;
+  forall_args       : parsed_template_arg list; (* Notice that these are shared between the calls *)
 }
 
 (****************************************************************)
@@ -301,6 +305,16 @@ type parsed_forall_template_call = {
 (****************************************************************)
 
 (** State predicates *)
+
+type unexpanded_parsed_init_state_predicate =
+	| Unexpanded_parsed_loc_assignment of automaton_name * location_name
+  | Unexpanded_parsed_forall_loc_assignment of
+  (*  index info          array name      array index                             location *)
+      forall_index_data * variable_name * parsed_discrete_arithmetic_expression * location_name
+	| Unexpanded_parsed_linear_predicate of linear_constraint
+	| Unexpanded_parsed_discrete_predicate of variable_name * parsed_boolean_expression
+
+type unexpanded_init_definition = unexpanded_parsed_init_state_predicate list
 
 type parsed_init_state_predicate =
 	| Parsed_loc_assignment of automaton_name * location_name

--- a/src/lib/Templates.ml
+++ b/src/lib/Templates.ml
@@ -390,7 +390,7 @@ let expand_synt_arrays_automata (g_decls : variable_declarations) (synt_vars : s
 let expand_forall_call g_decls { forall_index; forall_lb; forall_ub; forall_template; forall_aut_name; forall_args } =
   let forall_lb_val = eval_parsed_arithmetic_expr g_decls forall_lb in
   let forall_ub_val = eval_parsed_arithmetic_expr g_decls forall_ub in
-  let indices = List.init (forall_ub_val - forall_lb_val) (fun i -> i + forall_lb_val) in
+  let indices = List.init (forall_ub_val - forall_lb_val + 1) (fun i -> i + forall_lb_val) in
   let instantiate_arg idx = fun arg ->
     match arg with
       | Arg_name name ->

--- a/src/lib/Templates.ml
+++ b/src/lib/Templates.ml
@@ -84,7 +84,15 @@ let instantiate_convex_predicate (param_map : var_map) (inv : convex_predicate) 
 
 let rec instantiate_linear_term (param_map : var_map) (term : unexpanded_linear_term) : unexpanded_linear_term =
   match term with
-    | Unexpanded_constant _ | Unexpanded_variable (_, Var_name _) -> term
+    | Unexpanded_constant _ -> term
+    | Unexpanded_variable (c, Var_name name) -> begin
+        match Hashtbl.find_opt param_map name with
+          | None ->  Unexpanded_variable (c, Var_name name)
+          | Some (Arg_name name') -> Unexpanded_variable (c, Var_name name')
+          | Some (Arg_int i_val) -> Unexpanded_constant i_val
+          | Some (Arg_float f_val) -> Unexpanded_constant f_val
+          | Some (Arg_bool _) -> failwith "[instantiate_linear_term]: boolean variable in linear constraint."
+    end
     | Unexpanded_variable (c, Var_array_access (arr_name, index)) ->
         let index' = instantiate_discrete_arithmetic_expression param_map index in
         Unexpanded_variable (c, Var_array_access (arr_name, index'))

--- a/src/lib/Templates.ml
+++ b/src/lib/Templates.ml
@@ -31,6 +31,7 @@ and eval_parsed_term g_decls = function
 and eval_parsed_factor g_decls = function
   | Parsed_constant v -> NumConst.to_bounded_int (ParsedValue.to_numconst_value v)
   | Parsed_variable (name, _) -> expand_const_var g_decls name
+  | Parsed_nested_expr expr -> eval_parsed_arithmetic_expr g_decls expr
   | _ -> failwith eval_expr_err_msg
 
 and expand_const_var g_decls name =
@@ -40,7 +41,7 @@ and expand_const_var g_decls name =
     List.find_map Fun.id (List.map inspect_decls_of_type decls)
   in
   match inspect_all_decls g_decls with
-    | None -> failwith "[expand_model]: Size of syntatic array is a non-constant variable."
+    | None -> failwith eval_expr_err_msg
     | Some expr -> eval_parsed_boolean_expression g_decls expr
 
 let find_arr_len_opt arr_name =
@@ -80,6 +81,12 @@ let instantiate_discrete_arithmetic_expression (param_map : var_map) : parsed_di
 
 let instantiate_convex_predicate (param_map : var_map) (inv : convex_predicate) : convex_predicate =
   List.map (instantiate_discrete_boolean_expression param_map) inv
+
+let indices_from_forall_index_data g_decls forall_index_data =
+  let { forall_index_name = _; forall_lb; forall_ub } = forall_index_data in
+  let forall_lb_val = eval_parsed_arithmetic_expr g_decls forall_lb in
+  let forall_ub_val = eval_parsed_arithmetic_expr g_decls forall_ub in
+  List.init (forall_ub_val - forall_lb_val + 1) (fun i -> i + forall_lb_val)
 
 (*****************************************************************************)
 (* Instantiation of templates *)
@@ -387,14 +394,14 @@ let expand_synt_arrays_automaton (g_decls : variable_declarations) (synt_vars : 
 let expand_synt_arrays_automata (g_decls : variable_declarations) (synt_vars : synt_vars_data) : unexpanded_parsed_automaton list -> parsed_automaton list =
   List.map (expand_synt_arrays_automaton g_decls synt_vars)
 
-let expand_forall_call g_decls { forall_index; forall_lb; forall_ub; forall_template; forall_aut_name; forall_args } =
-  let forall_lb_val = eval_parsed_arithmetic_expr g_decls forall_lb in
-  let forall_ub_val = eval_parsed_arithmetic_expr g_decls forall_ub in
-  let indices = List.init (forall_ub_val - forall_lb_val + 1) (fun i -> i + forall_lb_val) in
+let expand_forall_call g_decls { forall_index_data; forall_template; forall_aut_name; forall_args } =
+  let indices = indices_from_forall_index_data g_decls forall_index_data in
   let instantiate_arg idx = fun arg ->
     match arg with
       | Arg_name name ->
-          if name = forall_index then Arg_int (NumConst.numconst_of_int idx) else arg
+          if name = forall_index_data.forall_index_name then
+            Arg_int (NumConst.numconst_of_int idx)
+          else arg
       | _ -> arg
   in
   let build_call idx =
@@ -404,16 +411,38 @@ let expand_forall_call g_decls { forall_index; forall_lb; forall_ub; forall_temp
   in
   List.map build_call indices
 
+let expand_init_state_predicate g_decls = function
+    | Unexpanded_parsed_forall_loc_assignment (index_data, arr_name, arr_idx, loc_name) ->
+        let indices = indices_from_forall_index_data g_decls index_data in
+        let instantiate_arr_idx i =
+          let aux_var_tbl =
+            Hashtbl.of_seq (List.to_seq [(index_data.forall_index_name, Arg_int (NumConst.numconst_of_int i))])
+          in
+          (* instantiate index expression with respect to the forall variable *)
+          instantiate_discrete_arithmetic_expression aux_var_tbl arr_idx |>
+          (* ... then evaluate it, to obtain a concrete number *)
+          eval_parsed_arithmetic_expr g_decls
+        in
+        List.map (fun i -> Parsed_loc_assignment (gen_access_id arr_name (instantiate_arr_idx i), loc_name)) indices
+    | Unexpanded_parsed_loc_assignment (aut, loc) -> [Parsed_loc_assignment (aut, loc)]
+    | Unexpanded_parsed_linear_predicate constr -> [Parsed_linear_predicate constr]
+    | Unexpanded_parsed_discrete_predicate (name, bool_expr) ->
+        [Parsed_discrete_predicate (name, bool_expr)]
+
+let expand_init_definition g_decls = List.concat_map (expand_init_state_predicate g_decls)
+
 let expand_model (unexpanded_parsed_model : unexpanded_parsed_model) : parsed_model =
   let g_decls = unexpanded_parsed_model.unexpanded_variable_declarations in
 
   (* Expand foralls *)
-  let forall_calls = unexpanded_parsed_model.forall_template_calls in
-  let forall_calls' = List.concat_map (expand_forall_call g_decls) forall_calls in
-
-  let all_calls = unexpanded_parsed_model.template_calls @ forall_calls' in
+  let forall_calls =
+    unexpanded_parsed_model.forall_template_calls |>
+    List.concat_map (expand_forall_call g_decls)
+  in
+  let all_calls = unexpanded_parsed_model.template_calls @ forall_calls in
   let instantiated_automata = instantiate_automata unexpanded_parsed_model.template_definitions all_calls in
   let all_automata = unexpanded_parsed_model.unexpanded_automata @ instantiated_automata in
+
   let synt_vars =
     List.concat_map
       (fun ((len, kind), names) -> List.map (fun name -> (name, kind, eval_parsed_arithmetic_expr g_decls len)) names)
@@ -430,9 +459,14 @@ let expand_model (unexpanded_parsed_model : unexpanded_parsed_model) : parsed_mo
           Parsed_uncontrollable_actions (expand_name_or_access_list g_decls actions)
       | Unexpanded_parsed_no_controllable_actions -> Parsed_no_controllable_actions
   in
+
+  let expanded_init_definition =
+    expand_init_definition g_decls unexpanded_parsed_model.unexpanded_init_definition
+  in
+
   { controllable_actions  = expanded_controllable_actions;
-    variable_declarations = (unexpanded_parsed_model.unexpanded_variable_declarations @ expanded_decls);
+    variable_declarations = unexpanded_parsed_model.unexpanded_variable_declarations @ expanded_decls;
     fun_definitions       = unexpanded_parsed_model.unexpanded_fun_definitions;
     automata              = expanded_automata;
-    init_definition       = unexpanded_parsed_model.unexpanded_init_definition;
+    init_definition       = expanded_init_definition;
   }

--- a/tests/testcases/templates/syntatic_check.imi
+++ b/tests/testcases/templates/syntatic_check.imi
@@ -1,0 +1,45 @@
+var
+    id : int;
+    k = 2 : constant;
+    IDLE = -1 : int;
+    N = 2 : int;
+
+synt_var
+    x : clock array (N);
+    acts : action array (N * 2 + 1);
+    params : parameter array (1 + N + N);
+
+template p(i : int)
+
+actions: acts[2 * i];
+
+loc A: invariant x[i] <= params[2 * i]
+  when id = IDLE do { x[i] := 0 } sync acts[2 * i] goto req;
+
+loc req: invariant x[i] <= k
+  when x[i] <= k do { x[i + 5 * 0] := 0; id := i } goto waiting;
+
+loc waiting: invariant True
+  when id = IDLE do { x[i] := 0 } goto req;
+  when id = i & x[i] > k goto cs;
+
+loc cs: invariant True
+  when True do { id := IDLE } goto A;
+
+end
+
+forall i in [0, 2]: instantiate p[i] := p(i);
+
+init := {
+
+    discrete =
+        id := IDLE,
+    ;
+
+    continuous =
+        x[0] = 0
+      & x[1] = 0
+    ;
+}
+
+end

--- a/tests/testcases/templates/syntatic_check.imi
+++ b/tests/testcases/templates/syntatic_check.imi
@@ -13,7 +13,7 @@ template p(i : int)
 
 actions: acts[2 * i];
 
-loc A: invariant x[i] <= params[2 * i]
+loc A: invariant x[i] <= params[i]
   when id = IDLE do { x[i] := 0 } sync acts[2 * i] goto req;
 
 loc req: invariant x[i] <= k
@@ -28,17 +28,18 @@ loc cs: invariant True
 
 end
 
-forall i in [0, 2]: instantiate p[i] := p(i);
+forall i in [0, 1]: instantiate p[i] := p(i);
 
 init := {
 
     discrete =
+        forall i in [0, 1]: loc[p[i]] := A,
         id := IDLE,
     ;
 
     continuous =
-        x[0] = 0
-      & x[1] = 0
+        forall i in [0, 1]: x[i] = i &
+        forall i in [0, 1]: params[i] >= 0
     ;
 }
 


### PR DESCRIPTION
Usage:
```
forall i in [lb, rb]: instantiate a[i] := p(i, ...);
```
This will expand to:
```
instantiate a___i := p(i, ...);
```
for each `i` between `lb` and `rb`. Note that these can be arbitrary expressions. One can use `i` in any way in the parameters of `p`.