### PR TITLE
Forall in action declarations

### DIFF
--- a/doc/IMITATOR-user-manual.tex
+++ b/doc/IMITATOR-user-manual.tex
@@ -2068,6 +2068,7 @@ If a variable is passed, then this is done by reference.
 All these constructions are exemplified in the following snippet:
 
 \begin{example}
+All these constructions are exemplified in the following snippet:
 \begin{IMITATORmodel}
 var
     id        : int;

--- a/src/lib/ModelParser.mly
+++ b/src/lib/ModelParser.mly
@@ -574,12 +574,21 @@ prolog:
 /************************************************************/
 
 actions_declarations:
-	| CT_ACTIONS COLON name_or_array_access_list SEMICOLON { $3 }
+	| CT_ACTIONS COLON action_declarations_list SEMICOLON { $3 }
 	/** NOTE: deprecated since 3.4 */
-	| CT_SYNCLABS COLON name_or_array_access_list SEMICOLON {
+	| CT_SYNCLABS COLON action_declarations_list SEMICOLON {
 			print_warning ("The syntax `synclabs` is deprecated since version 3.4; please use `actions` instead.");
 	$3 }
 ;
+
+/************************************************************/
+
+action_declarations_list:
+  | name_or_array_access COMMA action_declarations_list { (Single_action $1) :: $3 }
+  | name_or_array_access comma_opt { [Single_action $1] }
+  | forall_common_prefix NAME LSQBRA arithmetic_expression RSQBRA COMMA action_declarations_list { Multiple_actions ($1, $2, $4) :: $7 }
+  | forall_common_prefix NAME LSQBRA arithmetic_expression RSQBRA comma_opt { [Multiple_actions ($1, $2, $4)] }
+
 
 /************************************************************/
 

--- a/src/lib/ParsingStructure.mli
+++ b/src/lib/ParsingStructure.mli
@@ -279,14 +279,24 @@ type unexpanded_parsed_location = {
 	unexpanded_transitions : unexpanded_transition list;
 }
 
+type forall_index_data = {
+  forall_index_name : variable_name;
+  forall_lb         : parsed_discrete_arithmetic_expression;
+  forall_ub         : parsed_discrete_arithmetic_expression;
+}
+
 type parsed_automaton = automaton_name * action_name list * parsed_location list
 
-type unexpanded_parsed_automaton = automaton_name * name_or_access list * unexpanded_parsed_location list
+type action_declaration =
+  | Single_action of name_or_access
+  | Multiple_actions of forall_index_data * variable_name * parsed_discrete_arithmetic_expression
+
+type unexpanded_parsed_automaton = automaton_name * action_declaration list * unexpanded_parsed_location list
 
 type parsed_template_definition = {
     template_name       : template_name;
     template_parameters : (variable_name * DiscreteType.template_var_type) list;
-    template_body       : name_or_access list * unexpanded_parsed_location list
+    template_body       : action_declaration list * unexpanded_parsed_location list
 }
 
 type parsed_template_arg =
@@ -298,12 +308,6 @@ type parsed_template_arg =
 type parsed_template_call =
  (* name             template used   parameters passed to template *)
     automaton_name * template_name * (parsed_template_arg list)
-
-type forall_index_data = {
-  forall_index_name : variable_name;
-  forall_lb         : parsed_discrete_arithmetic_expression;
-  forall_ub         : parsed_discrete_arithmetic_expression;
-}
 
 type parsed_forall_template_call = {
   forall_index_data : forall_index_data;


### PR DESCRIPTION
This PR adds support for the usage of the `forall` construct in the declaration of the actions of an automaton.