### PR TITLE
Add compilation to byte code

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -1,6 +1,8 @@
 (executable
  (name IMITATOR)
+ (modes byte exe)
  (libraries lib)
+ (ocamlc_flags (-g) (-I %{env:OPAM_SWITCH_PREFIX=}/lib/gmp/) (-I %{env:OPAM_SWITCH_PREFIX=}/lib/ppl))
  (link_flags
   (:include link_flags.%{system})
   (:standard

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -2,7 +2,6 @@
  (name IMITATOR)
  (modes byte exe)
  (libraries lib)
- (ocamlc_flags (-g) (-I %{env:OPAM_SWITCH_PREFIX=}/lib/gmp/) (-I %{env:OPAM_SWITCH_PREFIX=}/lib/ppl))
  (link_flags
   (:include link_flags.%{system})
   (:standard
@@ -35,7 +34,10 @@
 (env
  (dev
   (flags
-   (:standard -warn-error -A))))
+   (:standard -warn-error -A -g)
+   (-I %{env:OPAM_SWITCH_PREFIX=}/lib/gmp/)
+   (-I %{env:OPAM_SWITCH_PREFIX=}/lib/ppl)
+  )))
 
 
 (rule


### PR DESCRIPTION
With this modification, running `dune build` will also produce a byte code executable under `_build/default/src/bin`, named `IMITATOR.bc`. This can be used for debugging IMITATOR with `ocamldebug`.