### PR TITLE
Patch on PPL to avoid freeing pointers to OCaml values

### DIFF
--- a/.github/patches/ppl_gc.patch
+++ b/.github/patches/ppl_gc.patch
@@ -1,4 +1,4 @@
---- interfaces/OCaml/ppl_interface_generator_ocaml_cc_code.m4
+--- interfaces/OCaml/ppl_interface_generator_ocaml_cc_code.m4.orig
 +++ interfaces/OCaml/ppl_interface_generator_ocaml_cc_code.m4
 1108c1108,1110
 <   delete p_@CLASS@_iterator_val(v);
@@ -7,7 +7,7 @@
 > dnl so commenting these lines will not create memory leaks.
 > //  delete p_@CLASS@_iterator_val(v);
 
---- interfaces/OCaml/ppl_interface_generator_ocaml_hh_code.m4
+--- interfaces/OCaml/ppl_interface_generator_ocaml_hh_code.m4.orig
 +++ interfaces/OCaml/ppl_interface_generator_ocaml_hh_code.m4
 47,48c47,50
 <    if (!marked(actual_p_@CLASS@_val(v)))
@@ -18,7 +18,7 @@
 > //   if (!marked(actual_p_@CLASS@_val(v)))
 > //      delete actual_p_@CLASS@_val(v);
 
---- interfaces/OCaml/ppl_ocaml_common.cc
+--- interfaces/OCaml/ppl_ocaml_common.cc.orig
 +++ interfaces/OCaml/ppl_ocaml_common.cc
 735c735,737
 <   delete p_MIP_Problem_val(v);

--- a/.github/patches/ppl_gc.patch
+++ b/.github/patches/ppl_gc.patch
@@ -1,0 +1,34 @@
+--- interfaces/OCaml/ppl_interface_generator_ocaml_cc_code.m4
++++ interfaces/OCaml/ppl_interface_generator_ocaml_cc_code.m4
+1108c1108,1110
+<   delete p_@CLASS@_iterator_val(v);
+---
+> dnl NOTE: This is causing memory issues with the garbage collector in OCaml. We believe that the GC will clean these references anyway,
+> dnl so commenting these lines will not create memory leaks.
+> //  delete p_@CLASS@_iterator_val(v);
+
+--- interfaces/OCaml/ppl_interface_generator_ocaml_hh_code.m4
++++ interfaces/OCaml/ppl_interface_generator_ocaml_hh_code.m4
+47,48c47,50
+<    if (!marked(actual_p_@CLASS@_val(v)))
+<       delete actual_p_@CLASS@_val(v);
+---
+> dnl NOTE: This is causing memory issues with the garbage collector in OCaml. We believe that the GC will clean these references anyway,
+> dnl so commenting these lines will not create memory leaks.
+> //   if (!marked(actual_p_@CLASS@_val(v)))
+> //      delete actual_p_@CLASS@_val(v);
+
+--- interfaces/OCaml/ppl_ocaml_common.cc
++++ interfaces/OCaml/ppl_ocaml_common.cc
+735c735,737
+<   delete p_MIP_Problem_val(v);
+---
+> // NOTE: This is causing memory issues with the garbage collector in OCaml. We believe that the GC will clean these references anyway,
+> // so commenting these lines will not create memory leaks.
+> //  delete p_MIP_Problem_val(v);
+764c766,768
+<   delete p_PIP_Problem_val(v);
+---
+> // NOTE: This is causing memory issues with the garbage collector in OCaml. We believe that the GC will clean these references anyway,
+> // so commenting these lines will not create memory leaks.
+> //  delete p_PIP_Problem_val(v);

--- a/.github/scripts/install-ppl.sh
+++ b/.github/scripts/install-ppl.sh
@@ -9,6 +9,8 @@ unzip -qq ppl-${PPL_VERSION}.zip
 
 cd ppl-${PPL_VERSION}
 
+patch <"${PATCH_FOLDER}/ppl_gc.patch"
+
 # Patch clang for OSX
 if [[ "$RUNNER_OS" = "macOS" ]]; then
     # patch clang

--- a/.github/scripts/install-ppl.sh
+++ b/.github/scripts/install-ppl.sh
@@ -9,7 +9,7 @@ unzip -qq ppl-${PPL_VERSION}.zip
 
 cd ppl-${PPL_VERSION}
 
-patch <"${PATCH_FOLDER}/ppl_gc.patch"
+patch -p0 <"${PATCH_FOLDER}/ppl_gc.patch"
 
 # Patch clang for OSX
 if [[ "$RUNNER_OS" = "macOS" ]]; then

--- a/src/lib/LinearConstraint.ml
+++ b/src/lib/LinearConstraint.ml
@@ -4576,8 +4576,6 @@ let get_disjuncts (p_nnconvex_constraint : p_nnconvex_constraint) =
 		ippl_nncc_increment_iterator iterator;
 	done;
 
-	(* let _ = ippl_nncc_begin_iterator p_nnconvex_constraint in *)
-
 	(* Return disjuncts *)
 	let result = List.rev (!disjuncts) in
 

--- a/src/lib/LinearConstraint.ml
+++ b/src/lib/LinearConstraint.ml
@@ -4570,13 +4570,13 @@ let get_disjuncts (p_nnconvex_constraint : p_nnconvex_constraint) =
 
 		(* Add it to the list of disjuncts *)
 		(*** NOTE: seems necessary to copy the disjunct first! (otherwise we get some strange segmentation fault) ***)
-		disjuncts := (p_copy disjunct) :: !disjuncts;
+		disjuncts := disjunct :: !disjuncts;
 
 		(* Increment the iterator *)
 		ippl_nncc_increment_iterator iterator;
 	done;
 
-	let _ = ippl_nncc_begin_iterator p_nnconvex_constraint in
+	(* let _ = ippl_nncc_begin_iterator p_nnconvex_constraint in *)
 
 	(* Return disjuncts *)
 	let result = List.rev (!disjuncts) in


### PR DESCRIPTION
This PR adds a patch to PPL so that it does not perform any `free` in pointers that are pointing to OCaml values. These pointers were being freed by OCaml's garbage collector anyway, so it is not necessary to free them in the PPL side. We believe that this is what were causing the segmentation faults.

Note: since the `build.sh` only installs ppl if you don't have it already, you have to first uninstall ppl for the change to make effect. Alternatively, you can create a new switch in opam or modify the build script to reinstall ppl.