### PR TITLE
ci: run tests and enforce failure threshold

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -175,15 +175,6 @@ dune build
 #   exit 1
 # }
 
-# rename artefact
-if [ ! -z "${GITHUB_WORKSPACE}" ]; then
-  information "Renaming artefact..."
-  cd bin
-  platform=$(echo "${RUNNER_OS}" | awk '{print tolower($1)}')
-  tag="${GITHUB_REF_NAME##*/}"
-  mv "imitator" "imitator-${tag}-${platform}-amd64"
-fi
-
 rm -f $err
 success "IMITATOR has been built successfully."
 

--- a/.github/scripts/check_test_results.py
+++ b/.github/scripts/check_test_results.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Fail when test results exceed the allowed failure threshold."
+    )
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=Path("tests/tests.log"),
+        help="Path to the test log (default: tests/tests.log).",
+    )
+    parser.add_argument(
+        "--max-failures",
+        type=int,
+        required=True,
+        help="Maximum allowed number of failed benchmarks or test cases.",
+    )
+    return parser.parse_args()
+
+
+def failed_count(log, name, all_passed_pattern):
+    failed = re.search(
+        r"^(\d+)/(\d+) {} failed\.$".format(name),
+        log,
+        re.MULTILINE,
+    )
+    if failed:
+        return int(failed.group(1)), int(failed.group(2))
+
+    all_passed = re.search(all_passed_pattern, log, re.MULTILINE)
+    if all_passed:
+        return 0, int(all_passed.group(2))
+
+    raise ValueError("Could not find the {} summary".format(name))
+
+
+def main():
+    args = parse_args()
+
+    if args.max_failures < 0:
+        sys.exit("--max-failures must be zero or greater")
+
+    if not args.log.is_file():
+        sys.exit("Test log was not generated: {}".format(args.log))
+
+    log = args.log.read_text(encoding="utf-8", errors="replace")
+
+    try:
+        failed_benchmarks, total_benchmarks = failed_count(
+            log,
+            "benchmarks",
+            r"^.*All benchmarks \((\d+)/(\d+)\) passed successfully\.$",
+        )
+        failed_test_cases, total_test_cases = failed_count(
+            log,
+            "test cases",
+            r"^All test cases \((\d+)/(\d+)\) passed successfully\.$",
+        )
+    except ValueError as error:
+        sys.exit("{} in {}".format(error, args.log))
+
+    print(
+        "Failed benchmarks: {}/{}; failed test cases: {}/{}; "
+        "maximum allowed: {}".format(
+            failed_benchmarks,
+            total_benchmarks,
+            failed_test_cases,
+            total_test_cases,
+            args.max_failures,
+        )
+    )
+
+    if (
+        failed_benchmarks > args.max_failures
+        or failed_test_cases > args.max_failures
+    ):
+        sys.exit("Test failure threshold exceeded")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/prepare-artifact.sh
+++ b/.github/scripts/prepare-artifact.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+case "$(uname)" in
+Linux)
+  platform="linux"
+  ;;
+Darwin)
+  platform="macos"
+  ;;
+*)
+  echo "Unsupported platform: $(uname)" >&2
+  exit 1
+  ;;
+esac
+
+tag="${GITHUB_REF_NAME##*/}"
+mv "bin/imitator" "bin/imitator-${tag}-${platform}-amd64"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,6 +11,8 @@ jobs:
           - ubuntu-22.04
           - macos-latest
     runs-on: ${{ matrix.os }}
+    env:
+      MAX_ALLOWED_TEST_FAILURES: 4
     steps:
       # setup repository
       - name: Checkout
@@ -21,9 +23,22 @@ jobs:
         run: .github/scripts/build.sh
         shell: bash
 
+      # run tests
+      - name: Run and check tests
+        run: |
+          python tests/test.py
+          python .github/scripts/check_test_results.py \
+            --max-failures "$MAX_ALLOWED_TEST_FAILURES"
+        shell: bash
+
       # build documentation
       - name: Documentation
         run: .github/scripts/documentation.sh
+        shell: bash
+
+      # prepare artifacts
+      - name: Prepare artifact
+        run: .github/scripts/prepare-artifact.sh
         shell: bash
 
       # upload artifacts


### PR DESCRIPTION
## Summary

- Parse `tests/tests.log` after execution.
- Fail CI when failed benchmarks or test cases exceed the configured threshold (e.g., 4).
- Fail when the test log is missing or malformed.
- Delay binary renaming until after tests so `tests/test.py` can find `bin/imitator`.
- Extract artifact preparation into a dedicated script.

## Validation

- Ran the complete test suite locally.
- Verified that 4 failures pass with a threshold of 4.
- Verified that exceeding the threshold returns a failure.
- Verified all-passing and malformed-log cases.
- Validated workflow YAML and shell syntax.