### PR TITLE
refactor: remove duplicate library flags and streamline dune configur…

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -167,7 +167,7 @@ dune clean
 
 # Build IMITATOR
 information "Building IMITATOR..."
-dune build
+dune build --stop-on-first-error
 
 # TODO: uncomment when bugs are fixed
 # dune build &>$err || {

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -167,13 +167,15 @@ dune clean
 
 # Build IMITATOR
 information "Building IMITATOR..."
-dune build --stop-on-first-error
+dune build --stop-on-first-error || {
+  error "An issue has occurred while building IMITATOR."
+  exit 1
+}
 
-# TODO: uncomment when bugs are fixed
-# dune build &>$err || {
-#   error "An issue has occured while building IMITATOR. Please check the error log."
-#   exit 1
-# }
+if [ ! -x "bin/imitator" ]; then
+  error "Binary 'bin/imitator' does not exist after dune build."
+  exit 1
+fi
 
 rm -f $err
 success "IMITATOR has been built successfully."

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -140,7 +140,8 @@ opam install -y extlib fileutils oasis alcotest menhir &>$err || {
 # install mlgmp
 information "Installing mlgmp..."
 
-if [ ! -d "$(opam var lib)/gmp" ]; then
+gmp_lib_dir="$(opam var lib)/gmp"
+if [ ! -d "$gmp_lib_dir" ] || ! find "$gmp_lib_dir" -maxdepth 1 -type f -name 'gmp*.cmx' | grep -q .; then
   bash "${SCRIPT_FOLDER}/install-mlgmp.sh" &>$err || {
     error "An issue has occured while installing mlgmp. Please check the error log."
     exit 1
@@ -152,7 +153,8 @@ fi
 # instal ppl
 information "Installing PPL..."
 
-if [ ! -d "$(opam var lib)/ppl" ]; then
+ppl_lib_dir="$(opam var lib)/ppl"
+if [ ! -d "$ppl_lib_dir" ] || ! find "$ppl_lib_dir" -maxdepth 1 -type f -name 'ppl_ocaml*.cmx' | grep -q .; then
   bash "${SCRIPT_FOLDER}/install-ppl.sh" &>$err || {
     error "An issue has occured while installing plp. Please check the error log."
     exit 1

--- a/.github/scripts/install-mlgmp.sh
+++ b/.github/scripts/install-mlgmp.sh
@@ -29,6 +29,24 @@ make install -s &>$err || {
     exit 1
 }
 
+information "Installing mlgmp OCaml native metadata..."
+GMP_OCAML_LIB_DIR="$(opam var lib)/gmp"
+GMP_OCAML_CMX_FILES=$(find . -type f -name 'gmp*.cmx')
+
+if [ -z "${GMP_OCAML_CMX_FILES}" ]; then
+    error "mlgmp OCaml native metadata files (*.cmx) were not found."
+    cd ..
+    rm -rf mlgmp
+    exit 1
+fi
+
+find . -type f -name 'gmp*.cmx' -exec cp {} "${GMP_OCAML_LIB_DIR}" \; &>$err || {
+    error "An issue has occured while installing mlgmp OCaml native metadata."
+    cd ..
+    rm -rf mlgmp
+    exit 1
+}
+
 cd ..
 rm -rf mlgmp
 

--- a/.github/scripts/install-ppl.sh
+++ b/.github/scripts/install-ppl.sh
@@ -55,6 +55,24 @@ make install &>$err || {
     exit 1
 }
 
+information "Installing PPL-${PPL_VERSION} OCaml native metadata..."
+PPL_OCAML_LIB_DIR="$(opam var lib)/ppl"
+PPL_OCAML_CMX_FILES=$(find . -type f -name 'ppl_ocaml*.cmx')
+
+if [ -z "${PPL_OCAML_CMX_FILES}" ]; then
+    error "PPL-${PPL_VERSION} OCaml native metadata files (*.cmx) were not found."
+    cd ../
+    rm -rf ppl-${PPL_VERSION}* $(opam var lib)/ppl
+    exit 1
+fi
+
+find . -type f -name 'ppl_ocaml*.cmx' -exec cp {} "${PPL_OCAML_LIB_DIR}" \; &>$err || {
+    error "An issue has occured while installing PPL-${PPL_VERSION} OCaml native metadata."
+    cd ../
+    rm -rf ppl-${PPL_VERSION}* $(opam var lib)/ppl
+    exit 1
+}
+
 cd ../
 rm -rf ppl-${PPL_VERSION}* $(opam var lib)/libppl.*
 

--- a/src/algorithms/AlgoPTG.ml
+++ b/src/algorithms/AlgoPTG.ml
@@ -115,7 +115,7 @@ type ptg_state =
 | InSP of state_index
 | NotInSP of DiscreteState.global_location * LinearConstraint.px_linear_constraint
 
-let zone_of_ptg_state (state_space : StateSpace.stateSpace) = function
+let _zone_of_ptg_state (state_space : StateSpace.stateSpace) = function
 	| InSP state_index -> (state_space#get_state state_index).px_constraint
 	| NotInSP (_, px) -> px
 

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -45,3 +45,7 @@
    (copy %{dep:IMITATOR.exe} %{target})
    (run chmod u+w %{target})
    (run strip %{target}))))
+
+(alias
+ (name default)
+ (deps imitator))

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -4,23 +4,20 @@
  (libraries algorithms exporter lib parsing entities utils)
  (flags
   (:standard -open Utils -open Entities -open Algorithms))
+ (ocamlc_flags
+  (:standard
+   -I
+   %{env:OPAM_SWITCH_PREFIX=}/lib/gmp
+   -I
+   %{env:OPAM_SWITCH_PREFIX=}/lib/ppl))
  (link_flags
   (:include link_flags.%{system})
-  (:standard
-   -cclib
-   -lppl
-   -cclib
-   -lppl_ocaml
-   -cclib
-   -lstdc++
-   -cclib
-   -lgmp
-   -cclib
-   -lgmpxx)))
+  (:standard -cclib -lppl -cclib -lstdc++)))
 
 (install
  (section bin)
- (files IMITATOR.exe))
+ (files
+  (IMITATOR.exe as imitator)))
 
 (rule
  (with-stdout-to
@@ -30,16 +27,12 @@
 (rule
  (with-stdout-to
   link_flags.macosx
-  (echo "()")))
+  (echo "(-ccopt -Wl,-no_warn_duplicate_libraries)")))
 
 (env
  (dev
   (flags
-   (:standard -warn-error -A -g)
-   (-I %{env:OPAM_SWITCH_PREFIX=}/lib/gmp/)
-   (-I %{env:OPAM_SWITCH_PREFIX=}/lib/ppl)
-  )))
-
+   (:standard -warn-error -A))))
 
 (rule
  (target imitator)
@@ -49,7 +42,6 @@
    (into ../../bin)))
  (action
   (progn
-   (echo "\nCopying main binary file to bin/imitator \226\128\166")
-   (run chmod u+w %{deps})
-   (run strip %{deps})
-   (copy %{deps} %{target}))))
+   (copy %{dep:IMITATOR.exe} %{target})
+   (run chmod u+w %{target})
+   (run strip %{target}))))

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -12,7 +12,17 @@
    %{env:OPAM_SWITCH_PREFIX=}/lib/ppl))
  (link_flags
   (:include link_flags.%{system})
-  (:standard -cclib -lppl -cclib -lstdc++)))
+  (:standard
+   -cclib
+   -lppl
+   -cclib
+   -lppl_ocaml
+   -cclib
+   -lstdc++
+   -cclib
+   -lgmp
+   -cclib
+   -lgmpxx)))
 
 (install
  (section bin)

--- a/src/entities/LinearConstraint.ml
+++ b/src/entities/LinearConstraint.ml
@@ -338,7 +338,7 @@ let debug_variable_names = fun v -> "v_" ^ (string_of_int v)
 
 (* For verbose print *)
 let debug_string_of_valuation_gen nb_dimensions valuation : string = "<" ^ (string_of_list_of_string_with_sep " , " (List.map (fun variable -> NumConst.string_of_numconst (valuation variable)) (list_of_interval 0 (nb_dimensions - 1)))) ^ ">"
-let debug_string_of_p_valuation valuation   = debug_string_of_valuation_gen !nb_parameters valuation
+let _debug_string_of_p_valuation valuation  = debug_string_of_valuation_gen !nb_parameters valuation
 let debug_string_of_px_valuation valuation  = debug_string_of_valuation_gen (!nb_parameters + !nb_clocks) valuation
 
 
@@ -2632,7 +2632,7 @@ let pxd_remove_dimensions = remove_dimensions
 
 
 (** Keep the lowest nb_dimensions in a linear_constraint *)
-let keep_lowest_dimensions nb_dimensions linear_constraint =
+let _keep_lowest_dimensions nb_dimensions linear_constraint =
 	(* Print some information *)
 	if verbose_mode_greater Verbose_total then (
 		print_message Verbose_total ("Function `keep_lowest_dimensions`: keep " ^ (string_of_int nb_dimensions) ^ ".");
@@ -6240,4 +6240,3 @@ let test_IH() =
 
 ;;
  test_IH() *)
-

--- a/src/exporter/PTA2Uppaal.ml
+++ b/src/exporter/PTA2Uppaal.ml
@@ -468,7 +468,7 @@ let only_assignment_in_update seq_code_bloc =
 
 (* Convert sequential code bloc into UPPAAL strings *)
 let rec string_of_seq_code_bloc ?(sep=";") variable_names seq_code_bloc =
-    let str_instructions = List.map (string_of_instruction variable_names) seq_code_bloc in
+    let str_instructions = List.map (string_of_instruction ~sep:sep variable_names) seq_code_bloc in
     OCamlUtilities.string_of_list_of_string_with_sep "\n" str_instructions
 
 (* Convert an instruction into UPPAAL string *)

--- a/src/parsing/ModelLexer.mll
+++ b/src/parsing/ModelLexer.mll
@@ -42,7 +42,7 @@ rule token = parse
 				open_in absolute_filename
 			)with
 				(* Lib.ModelParser.MenhirBasics.Error *)
-				| Error _
+				| Error
 				| Sys_error _ ->
 					(* Abort properly *)
 (* 					print_error(e); *)

--- a/src/parsing/ParsingStructureGraph.ml
+++ b/src/parsing/ParsingStructureGraph.ml
@@ -677,6 +677,9 @@ let declared_components_of_model parsed_model =
 (* Get a dependency graph as a list of relations between variables and functions *)
 (* Each relation is a pair representing a ref to a variable / function using another variable / function *)
 let dependency_graph ?(no_var_autoremove=false) declarations_info parsed_model parsed_property_opt =
+    (* The option is consumed later by ModelConverter when deciding whether to
+       remove unused variables/functions. Keep the argument for API clarity. *)
+    ignore no_var_autoremove;
 
     (* Function that return all component relations of a given function definition *)
     let function_relations (fun_def : parsed_fun_definition) =

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -10,7 +10,20 @@
  (modules ModelLexer PropertyLexer))
 
 (menhir
- (flags --dump --explain)
+ (flags
+  --dump
+  --explain
+  --unused-precedence-levels
+  --unused-token
+  CT_INFINITY
+  --unused-token
+  CT_NOSYNCOBS
+  --unused-token
+  CT_OBSERVER
+  --unused-token
+  CT_OBSERVER_CLOCK
+  --unused-token
+  CT_SPECIAL_RESET_CLOCK_NAME)
  (modules ModelParser PropertyParser))
 
 (rule
@@ -18,7 +31,25 @@
  (deps ModelParser.mly)
  (action
   (progn
-   (run menhir --table --dump --explain --base ModelParserConflictReport %{deps})
+   (run
+    menhir
+    --table
+    --dump
+    --explain
+    --unused-precedence-levels
+    --unused-token
+    CT_INFINITY
+    --unused-token
+    CT_NOSYNCOBS
+    --unused-token
+    CT_OBSERVER
+    --unused-token
+    CT_OBSERVER_CLOCK
+    --unused-token
+    CT_SPECIAL_RESET_CLOCK_NAME
+    --base
+    ModelParserConflictReport
+    %{deps})
    (run cp ModelParserConflictReport.conflicts ModelParser.conflicts))))
 
 (rule
@@ -26,7 +57,25 @@
  (deps PropertyParser.mly)
  (action
   (progn
-   (run menhir --table --dump --explain --base PropertyParserConflictReport %{deps})
+   (run
+    menhir
+    --table
+    --dump
+    --explain
+    --unused-precedence-levels
+    --unused-token
+    CT_INFINITY
+    --unused-token
+    CT_NOSYNCOBS
+    --unused-token
+    CT_OBSERVER
+    --unused-token
+    CT_OBSERVER_CLOCK
+    --unused-token
+    CT_SPECIAL_RESET_CLOCK_NAME
+    --base
+    PropertyParserConflictReport
+    %{deps})
    (run cp PropertyParserConflictReport.conflicts PropertyParser.conflicts))))
 
 (env

--- a/src/unit_tests/dune
+++ b/src/unit_tests/dune
@@ -7,7 +7,17 @@
   (run %{test} -e))
  (link_flags
   (:include link_flags.%{system})
-  (:standard -cclib -lppl -cclib -lstdc++)))
+  (:standard
+   -cclib
+   -lppl
+   -cclib
+   -lppl_ocaml
+   -cclib
+   -lstdc++
+   -cclib
+   -lgmp
+   -cclib
+   -lgmpxx)))
 
 (rule
  (with-stdout-to

--- a/src/unit_tests/dune
+++ b/src/unit_tests/dune
@@ -3,22 +3,23 @@
  (libraries alcotest fmt lib parsing entities utils)
  (flags
   (:standard -open Utils -open Entities))
- (action (run %{test} -e))
-  (link_flags
-  (:standard
-   -cclib
-   -lppl
-   -cclib
-   -lppl_ocaml
-   -cclib
-   -lstdc++
-   -cclib
-   -lgmp
-   -cclib
-   -lgmpxx))
- 
- )
+ (action
+  (run %{test} -e))
+ (link_flags
+  (:include link_flags.%{system})
+  (:standard -cclib -lppl -cclib -lstdc++)))
+
+(rule
+ (with-stdout-to
+  link_flags.linux
+  (echo "()")))
+
+(rule
+ (with-stdout-to
+  link_flags.macosx
+  (echo "(-ccopt -Wl,-no_warn_duplicate_libraries)")))
 
 (env
-  (dev
-    (flags (:standard -warn-error -A))))
+ (dev
+  (flags
+   (:standard -warn-error -A))))

--- a/src/utils/NumConst.ml
+++ b/src/utils/NumConst.ml
@@ -528,7 +528,7 @@ let random_integer min max =
 	let nb = get_num nb in
 
 	(* Compute random *)
-	let random_number : gmpz = Gmp.Z.urandomm (random_generator()) nb in
+	let random_number : gmpz = Gmp.Z.urandomm ~state:(random_generator()) ~n:nb in
 
 	(* 	let plouf = Gmp.Q.mpz_urandomm in *)
 


### PR DESCRIPTION
## Summary

This PR improves the Dune/build configuration and CI scripts for the IMITATOR binary.

It fixes Linux build issues introduced while removing duplicate linker flags, makes `dune build` produce the promoted `bin/imitator` binary by default, and improves dependency installation checks for native OCaml metadata files.

## Changes

- Restore required native linker flags for `gmp`, `gmpxx`, `ppl`, and `ppl_ocaml`.
- Keep macOS duplicate-library warnings quiet with a platform-specific linker flag.
- Add a Dune default alias so `dune build` builds/promotes `bin/imitator`.
- Update the CI build script to:
  - stop on the first Dune error,
  - verify that `bin/imitator` exists after the build,
  - reinstall `mlgmp` or `ppl` when required `.cmx` metadata files are missing.
- Update `install-mlgmp.sh` and `install-ppl.sh` to preserve OCaml native metadata files before cleaning build directories.
- Clean up several OCaml warnings by:
  - using explicit labels,
  - removing invalid wildcard usage,
  - prefixing intentionally unused private functions with `_`,
  - actually threading the `sep` parameter where needed.

## Testing

- `dune build`
- `dune runtest`
- `python tests/test.py`

All tests pass.