### PR TITLE
Fix parser errors in included model files

### DIFF
--- a/src/parsing/ModelLexer.mll
+++ b/src/parsing/ModelLexer.mll
@@ -51,7 +51,11 @@ rule token = parse
 			let lb = Lexing.from_channel c in
 			lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with Lexing.pos_fname = absolute_filename };
 
-			let p : ParsingStructure.unexpanded_parsed_model = ModelParser.main token lb in
+			let p : ParsingStructure.unexpanded_parsed_model =
+				try ModelParser.main token lb with
+					| Error ->
+						failwith ("Parsing error in included file `" ^ file_name ^ "`.")
+			in
 			INCLUDE p
     }
 


### PR DESCRIPTION
## Summary

Fix handling of syntax errors raised while parsing model files included with `#include`.

## Details

Previously, included files were parsed directly from `ModelLexer`. If Menhir raised a parser error inside the included file, the exception bypassed the normal parsing error handling path. IMITATOR aborted with a fatal exception and did not write the expected result file.

This change catches parser errors from included model parsing and converts them into a regular parsing failure.

## Validation

- `dune build --stop-on-first-error`
- `python tests/test.py`