### PR TITLE
ci: improve Docker Hub deployment caching

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -5,7 +5,6 @@ set -a
 # global variables for options
 
 FANCY=false
-err=./error.log
 
 # options for script
 
@@ -16,7 +15,7 @@ while getopts "hf" opt; do
     echo "Usage: $0 [-Options]"
     echo
     echo "Description:"
-    echo "This script builds IMITATOR. It also installs the necessary dependencies for the build."
+    echo "This script builds IMITATOR. Run install-deps.sh first when dependencies are missing."
     echo
     echo "Options list:"
     echo "    -h    Display this help message"
@@ -37,131 +36,34 @@ done
 
 if [ $FANCY = "true" ]; then
   error() { echo -e "\033[31mERROR: \033[0m$1"; }
-  warning() { echo -e "\033[33mWARNING: \033[0m$1"; }
   information() { echo -e "\033[32mINFO: \033[0m$1"; }
-  note() { echo -e "\033[34mNOTE: \033[0m$1"; }
   success() { echo -e "\033[92mSUCCESS: \033[0m$1"; }
-  cmd() { echo -e "\033[35m$1\033[0m"; }
 else
   error() { echo -e "ERROR: $1"; }
-  warning() { echo -e "WARNING: $1"; }
   information() { echo -e "INFO: $1"; }
-  note() { echo -e "NOTE: $1"; }
   success() { echo -e "SUCCESS: $1"; }
-  cmd() { echo -e "$1"; }
 fi
 
-# check OS
-case $(uname) in
-'Linux')
-  RUNNER_OS='Linux'
-  ;;
-'Darwin')
-  RUNNER_OS='macOS'
-  ;;
-*)
-  error "This script only supports Linux or OSX."
-  exit 1
-  ;;
-esac
-
-# ignore sudo commands when the user is root
-sudo() {
-  [[ $EUID = 0 ]] || set -- command sudo "$@"
-  "$@"
-}
-
 # script folder
-information "Setting up the environment..."
+information "Setting up the build environment..."
 
 if [ -z "${GITHUB_WORKSPACE}" ]; then
   SCRIPT_FOLDER=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-  PATCH_FOLDER="$(dirname $SCRIPT_FOLDER)/patches"
   ROOT_FOLDER="$(dirname $(dirname $SCRIPT_FOLDER))"
   cd "$ROOT_FOLDER"
-else
-  SCRIPT_FOLDER="${GITHUB_WORKSPACE}/.github/scripts"
-  PATCH_FOLDER="${GITHUB_WORKSPACE}/.github/patches"
 fi
 
-# install dependencies
-information "Installing dependencies for IMITATOR..."
-
-if [[ "$RUNNER_OS" = "Linux" ]]; then
-  DEBIAN_FRONTEND=noninteractive
-  sudo apt-get update -qq
-  sudo apt-get install -qq wget unzip curl build-essential libtinfo-dev g++ m4 opam python3 \
-    libgmp-dev libmpfr-dev libppl-dev graphviz plotutils &>$err || {
-    error "One of the depedencies had an issue installing itself. Please use the command $(cmd "apt-get update") or make sure that $(cmd "sudo") rights have been granted"
-    exit 1
-  }
-elif [[ "$RUNNER_OS" = "macOS" ]]; then
-  brew install wget opam gmp mpfr ppl graphviz plotutils &>$err || {
-    error "One of the depedencies had an issue installing itself. Please make sure that $(cmd "brew") is installed or that $(cmd "sudo") rights have been granted"
-    exit 1
-  }
-fi
-
-# python fix
-information "Fixing python symlink..."
-
-[ ! -x "$(command -v python)" ] && sudo ln -s $(which python3) "/usr/local/bin/python"
-
-# initialise opam
-information "Initialising opam..."
-
-[[ ${DOCKER_RUNNING} ]] && opam init -a --disable-sandboxing &>$err || opam init -a &>$err || {
-  error "An issue has occured while initialising opam. Please check the error log."
+if ! command -v opam >/dev/null 2>&1; then
+  error "opam is not installed. Please run .github/scripts/install-deps.sh first."
   exit 1
-}
-
-# switch to ocaml 4.14
-information "Switching to OCaml 4.14.2..."
+fi
 
 if ! opam switch list --short | grep -q '^imitator$'; then
-  opam switch create imitator 4.14.2 &>$err || {
-    error "An issue has occured while creating the switch 4.14.2. Please check the error log."
-    exit 1
-  }
-fi
-
-opam switch imitator
-eval $(opam env)
-
-# install opam and ocaml libraries
-
-information "Installing opam and OCaml libraries..."
-
-opam install -y extlib fileutils oasis alcotest menhir &>$err || {
-  error "An issue has occured while installing opam and OCaml libraries. Please check the error log."
+  error "opam switch 'imitator' is missing. Please run .github/scripts/install-deps.sh first."
   exit 1
-}
-
-# install mlgmp
-information "Installing mlgmp..."
-
-gmp_lib_dir="$(opam var lib)/gmp"
-if [ ! -d "$gmp_lib_dir" ] || ! find "$gmp_lib_dir" -maxdepth 1 -type f -name 'gmp*.cmx' | grep -q .; then
-  bash "${SCRIPT_FOLDER}/install-mlgmp.sh" &>$err || {
-    error "An issue has occured while installing mlgmp. Please check the error log."
-    exit 1
-  }
-else
-  note "mlgmp already installed. Skipping."
 fi
 
-# instal ppl
-information "Installing PPL..."
-
-ppl_lib_dir="$(opam var lib)/ppl"
-if [ ! -d "$ppl_lib_dir" ] || ! find "$ppl_lib_dir" -maxdepth 1 -type f -name 'ppl_ocaml*.cmx' | grep -q .; then
-  bash "${SCRIPT_FOLDER}/install-ppl.sh" &>$err || {
-    error "An issue has occured while installing plp. Please check the error log."
-    exit 1
-  }
-else
-  note "PPL already installed. Skipping."
-fi
+eval "$(opam env --switch=imitator)"
 
 # Cleaning previous builds
 information "Cleaning previous builds..."
@@ -179,7 +81,6 @@ if [ ! -x "bin/imitator" ]; then
   exit 1
 fi
 
-rm -f $err
 success "IMITATOR has been built successfully."
 
 exit 0

--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+set -a
+
+# global variables for options
+
+FANCY=false
+err=./error.log
+
+# options for script
+
+while getopts "hf" opt; do
+  case ${opt} in
+  h)
+    clear
+    echo "Usage: $0 [-Options]"
+    echo
+    echo "Description:"
+    echo "This script installs the dependencies needed to build IMITATOR."
+    echo
+    echo "Options list:"
+    echo "    -h    Display this help message"
+    echo "    -f    Fancy the output"
+    echo
+    exit 0
+    ;;
+  f)
+    FANCY=true
+    ;;
+  \?)
+    echo "Invalid option: $OPTARG. Executing the script without options."
+    ;;
+  esac
+done
+
+# initialize printing functions with or without -f option
+
+if [ $FANCY = "true" ]; then
+  error() { echo -e "\033[31mERROR: \033[0m$1"; }
+  warning() { echo -e "\033[33mWARNING: \033[0m$1"; }
+  information() { echo -e "\033[32mINFO: \033[0m$1"; }
+  note() { echo -e "\033[34mNOTE: \033[0m$1"; }
+  success() { echo -e "\033[92mSUCCESS: \033[0m$1"; }
+  cmd() { echo -e "\033[35m$1\033[0m"; }
+else
+  error() { echo -e "ERROR: $1"; }
+  warning() { echo -e "WARNING: $1"; }
+  information() { echo -e "INFO: $1"; }
+  note() { echo -e "NOTE: $1"; }
+  success() { echo -e "SUCCESS: $1"; }
+  cmd() { echo -e "$1"; }
+fi
+
+# check OS
+case $(uname) in
+'Linux')
+  RUNNER_OS='Linux'
+  ;;
+'Darwin')
+  RUNNER_OS='macOS'
+  ;;
+*)
+  error "This script only supports Linux or OSX."
+  exit 1
+  ;;
+esac
+
+# ignore sudo commands when the user is root
+sudo() {
+  [[ $EUID = 0 ]] || set -- command sudo "$@"
+  "$@"
+}
+
+# script folder
+information "Setting up the environment..."
+
+if [ -z "${GITHUB_WORKSPACE}" ]; then
+  SCRIPT_FOLDER=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+  PATCH_FOLDER="$(dirname $SCRIPT_FOLDER)/patches"
+  ROOT_FOLDER="$(dirname $(dirname $SCRIPT_FOLDER))"
+  cd "$ROOT_FOLDER"
+else
+  SCRIPT_FOLDER="${GITHUB_WORKSPACE}/.github/scripts"
+  PATCH_FOLDER="${GITHUB_WORKSPACE}/.github/patches"
+fi
+
+# install dependencies
+information "Installing dependencies for IMITATOR..."
+
+if [[ "$RUNNER_OS" = "Linux" ]]; then
+  DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update -qq
+  sudo apt-get install -qq wget unzip curl build-essential libtinfo-dev g++ m4 opam python3 \
+    libgmp-dev libmpfr-dev libppl-dev graphviz plotutils &>$err || {
+    error "One of the depedencies had an issue installing itself. Please use the command $(cmd "apt-get update") or make sure that $(cmd "sudo") rights have been granted"
+    exit 1
+  }
+elif [[ "$RUNNER_OS" = "macOS" ]]; then
+  brew install wget opam gmp mpfr ppl graphviz plotutils &>$err || {
+    error "One of the depedencies had an issue installing itself. Please make sure that $(cmd "brew") is installed or that $(cmd "sudo") rights have been granted"
+    exit 1
+  }
+fi
+
+# python fix
+information "Fixing python symlink..."
+
+[ ! -x "$(command -v python)" ] && sudo ln -s $(which python3) "/usr/local/bin/python"
+
+# initialise opam
+information "Initialising opam..."
+
+[[ ${DOCKER_RUNNING} ]] && opam init -a --disable-sandboxing &>$err || opam init -a &>$err || {
+  error "An issue has occured while initialising opam. Please check the error log."
+  exit 1
+}
+
+# switch to ocaml 4.14
+information "Switching to OCaml 4.14.2..."
+
+if ! opam switch list --short | grep -q '^imitator$'; then
+  opam switch create imitator 4.14.2 &>$err || {
+    error "An issue has occured while creating the switch 4.14.2. Please check the error log."
+    exit 1
+  }
+fi
+
+opam switch imitator
+eval $(opam env)
+
+# install opam and ocaml libraries
+
+information "Installing opam and OCaml libraries..."
+
+opam install -y extlib fileutils oasis alcotest menhir &>$err || {
+  error "An issue has occured while installing opam and OCaml libraries. Please check the error log."
+  exit 1
+}
+
+# install mlgmp
+information "Installing mlgmp..."
+
+gmp_lib_dir="$(opam var lib)/gmp"
+if [ ! -d "$gmp_lib_dir" ] || ! find "$gmp_lib_dir" -maxdepth 1 -type f -name 'gmp*.cmx' | grep -q .; then
+  bash "${SCRIPT_FOLDER}/install-mlgmp.sh" &>$err || {
+    error "An issue has occured while installing mlgmp. Please check the error log."
+    exit 1
+  }
+else
+  note "mlgmp already installed. Skipping."
+fi
+
+# instal ppl
+information "Installing PPL..."
+
+ppl_lib_dir="$(opam var lib)/ppl"
+if [ ! -d "$ppl_lib_dir" ] || ! find "$ppl_lib_dir" -maxdepth 1 -type f -name 'ppl_ocaml*.cmx' | grep -q .; then
+  bash "${SCRIPT_FOLDER}/install-ppl.sh" &>$err || {
+    error "An issue has occured while installing plp. Please check the error log."
+    exit 1
+  }
+else
+  note "PPL already installed. Skipping."
+fi
+
+rm -f $err
+success "IMITATOR dependencies have been installed successfully."
+
+exit 0

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -138,6 +138,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: imitator/imitator
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -146,6 +146,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            IMITATOR_GIT_HASH=${{ github.sha }}
+            IMITATOR_GIT_BRANCH=${{ github.ref_name }}
           cache-from: |
             type=gha,scope=docker-${{ hashFiles('Dockerfile', '.github/scripts/install-deps.sh', '.github/scripts/install-mlgmp.sh', '.github/scripts/install-ppl.sh', '.github/patches/**') }}
             type=gha

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,11 +37,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.opam
-          key: opam-${{ matrix.os }}-ocaml4.14.2-${{ hashFiles('.github/scripts/build.sh', '.github/scripts/install-mlgmp.sh', '.github/scripts/install-ppl.sh') }}
+          key: opam-${{ matrix.os }}-ocaml4.14.2-${{ hashFiles('.github/scripts/install-deps.sh', '.github/scripts/install-mlgmp.sh', '.github/scripts/install-ppl.sh') }}
           restore-keys: |
             opam-${{ matrix.os }}-ocaml4.14.2-
 
       # install dependencies
+      - name: Install dependencies
+        run: .github/scripts/install-deps.sh
+        shell: bash
+
+      # build IMITATOR
       - name: Run build
         run: .github/scripts/build.sh
         shell: bash
@@ -101,7 +106,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           files: |
             imitator-macos-*/bin/*
             imitator-ubuntu-*/bin/*
@@ -141,5 +146,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=docker-${{ hashFiles('Dockerfile', '.github/scripts/install-deps.sh', '.github/scripts/install-mlgmp.sh', '.github/scripts/install-ppl.sh', '.github/patches/**') }}
+            type=gha
+          cache-to: type=gha,mode=max,scope=docker-${{ hashFiles('Dockerfile', '.github/scripts/install-deps.sh', '.github/scripts/install-mlgmp.sh', '.github/scripts/install-ppl.sh', '.github/patches/**') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,16 @@ You can build, run, and develop IMITATOR using Docker. The Dockerfile has two st
 - `runtime`: the default final image, containing only the compiled `imitator` binary and runtime tools such as Graphviz and Plotutils.
 - `builder`: a development image with the Ubuntu packages, opam switch, OCaml libraries, mlgmp, PPL, and build tools needed to compile IMITATOR.
 
-Docker BuildKit is required for the cache mounts used by the Dockerfile. These mounts reuse apt and opam downloads across builds without copying those caches into the final image.
+Docker BuildKit is required for the cache mount used by the Dockerfile. The Docker build installs dependencies before copying the full source tree, so source-only changes can reuse the expensive Ubuntu/opam/mlgmp/PPL dependency layer. The apt package download cache is kept outside the image layer.
+
+The same split is available outside Docker:
+
+```bash
+.github/scripts/install-deps.sh
+.github/scripts/build.sh
+```
+
+Run `install-deps.sh` when setting up a machine or changing dependency scripts. Run `build.sh` for normal rebuilds once dependencies are installed.
 
 #### Building the Runtime Image
 
@@ -305,7 +314,13 @@ docker run --rm -it \
   imitator-dev
 ```
 
-Inside the interactive shell, the `imitator` opam switch is loaded from `/root/.bashrc`, so you can run OCaml tooling directly:
+Inside the interactive shell, the `imitator` opam switch is loaded from `/root/.bashrc`. Use the project build script for the standard build:
+
+```bash
+.github/scripts/build.sh
+```
+
+You can also run OCaml tooling directly:
 
 ```bash
 dune build
@@ -333,6 +348,7 @@ scripts/format.sh --check
 - The default image is for running IMITATOR, not for compiling it
 - Use `imitator-dev` for development commands such as `dune build`, formatting checks, and tests
 - The builder image also contains a copy of the source tree at `/imitator`; use `/workspace` when you want to work on your mounted checkout
+- The Dockerfile copies and runs `.github/scripts/install-deps.sh` before copying the full source tree; changing dependency scripts or patches invalidates the dependency layer, while ordinary source edits should reuse it
 - For non-interactive dev commands, run through Bash so `/root/.bashrc` is loaded, for example: `docker run --rm -v "$(pwd):/workspace" -w /workspace imitator-dev bash -ic 'dune build'`
 
 ## Questions?

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,27 +6,32 @@
 FROM ubuntu:22.04 AS builder
 LABEL maintainer="Jaime Arias <arias@lipn.univ-paris13.fr>"
 
-# DOCKER_RUNNING tells build.sh to init opam with --disable-sandboxing;
+# DOCKER_RUNNING tells install-deps.sh to init opam with --disable-sandboxing;
 # DEBIAN_FRONTEND keeps apt non-interactive.
 ENV DOCKER_RUNNING=true \
   DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /imitator
 
-# Copy the whole repository (see .dockerignore for what is excluded).
+# Copy only the dependency installer inputs first. This keeps the expensive
+# apt/opam/mlgmp/PPL setup cached when ordinary source files change.
+COPY .github/scripts/install-deps.sh .github/scripts/install-deps.sh
+COPY .github/scripts/install-mlgmp.sh .github/scripts/install-mlgmp.sh
+COPY .github/scripts/install-ppl.sh .github/scripts/install-ppl.sh
+COPY .github/patches .github/patches
+
+# Install the system packages, opam switch, OCaml libraries, mlgmp and PPL.
+# The apt cache mount persists package downloads across local builds without
+# copying them into the image layer. The opam switch is kept in this layer so
+# later source-only rebuilds can reuse it reliably from Docker's layer cache.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  bash .github/scripts/install-deps.sh
+
+# Copy the whole repository only after dependency setup (see .dockerignore for
+# what is excluded), then compile IMITATOR and promote the stripped binary.
 COPY . .
 
-# Build IMITATOR. build.sh installs the system packages, opam, the OCaml
-# switch, mlgmp and PPL, then runs `dune build`, which promotes a stripped,
-# statically-linked binary to /imitator/bin/imitator.
-#
-# The cache mounts persist apt downloads and the opam root (switch +
-# mlgmp/PPL bindings) across builds; build.sh already skips reinstalling
-# them when present, so warm rebuilds avoid recompiling PPL from source.
-# They live in the build cache only, never in a layer.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/root/.opam,sharing=locked \
-  bash .github/scripts/build.sh
+RUN bash .github/scripts/build.sh
 
 # Make the opam switch available by default in interactive dev shells.
 RUN echo 'eval "$(opam env --switch=imitator)"' >> /root/.bashrc
@@ -39,8 +44,10 @@ LABEL maintainer="Jaime Arias <arias@lipn.univ-paris13.fr>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Runtime dependencies:
-RUN apt-get update -qq \
+# Runtime dependencies. The apt cache mount mirrors the builder stage so local
+# rebuilds of this layer reuse previously downloaded packages.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update -qq \
   && apt-get install -y --no-install-recommends \
   graphviz \
   plotutils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # what is excluded), then compile IMITATOR and promote the stripped binary.
 COPY . .
 
-RUN bash .github/scripts/build.sh
+ARG IMITATOR_GIT_HASH
+ARG IMITATOR_GIT_BRANCH
+
+RUN IMITATOR_GIT_HASH="$IMITATOR_GIT_HASH" \
+  IMITATOR_GIT_BRANCH="$IMITATOR_GIT_BRANCH" \
+  bash .github/scripts/build.sh
 
 # Make the opam switch available by default in interactive dev shells.
 RUN echo 'eval "$(opam env --switch=imitator)"' >> /root/.bashrc

--- a/gen_build_info.py
+++ b/gen_build_info.py
@@ -51,6 +51,21 @@ ocaml_fmt = 'Some "{}"'
 git_fmt = "Retrieved git {}: {}"
 
 
+def ocaml_string(value):
+    """Escapes a Python string for a generated OCaml string literal."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def env_info(info):
+    """Returns git information provided by the build environment, if any."""
+    if info == "hash":
+        return os.environ.get("IMITATOR_GIT_HASH") or os.environ.get("GITHUB_SHA")
+    elif info == "branch":
+        return os.environ.get("IMITATOR_GIT_BRANCH") or os.environ.get("GITHUB_REF_NAME")
+    else:
+        raise NotImplementedError
+
+
 def get_ocaml_info(info):
     """Method that gets specific information from git and returns a typed value for Ocaml"""
     if info == "hash":  # NOTE: command is 'git rev-parse HEAD'
@@ -62,15 +77,18 @@ def get_ocaml_info(info):
 
     try:
         git_info = (subprocess.check_output(git_command)).rstrip().decode("utf-8")
-    except:  # Case: exception with problem (typically return code <> 1)
-        print("Error with git: give up git information")
-        # nothing
-        git_info = "?????"
+    except Exception:  # Case: exception with problem (typically return code <> 1)
+        git_info = env_info(info)
+        if git_info:
+            print("Error with git: using {} from build environment".format(info))
+        else:
+            print("Error with git: give up git information")
+            git_info = "?????"
 
     print(git_fmt.format(info, git_info))
 
     # Handle what to print in Ocaml
-    git_ocaml = ocaml_fmt.format(git_info)
+    git_ocaml = ocaml_fmt.format(ocaml_string(git_info))
     if git_info == "":
         git_ocaml = "None"
 


### PR DESCRIPTION
## Summary
- split dependency installation into `.github/scripts/install-deps.sh` and keep `.github/scripts/build.sh` focused on building
- update `Dockerfile` layering so dependency setup is cached before copying the full source tree
- scope Docker Hub deployment cache to dependency-layer inputs and update contributor docs

## Checks
- bash -n .github/scripts/install-deps.sh
- bash -n .github/scripts/build.sh
- .github/scripts/build.sh
- workflow YAML parse check